### PR TITLE
Fix auth time check to accomodate first second.

### DIFF
--- a/src/charmander/core.clj
+++ b/src/charmander/core.clj
@@ -88,9 +88,9 @@
 	(and
 		(= (str "https://securetoken.google.com/" (:aud data)) (:iss data))
 		(> (:exp data) now)
-		(< (:iat data) now)
+		(<= (:iat data) now)
 		(not (str/blank? (:sub data)))
-		(< (:auth_time data) now))))
+		(<= (:auth_time data) now))))
 
 (defn- authenticate 
 	"Core library method. Validates token using public key and returns formatted data"


### PR DESCRIPTION
Hello @alekcz ,

Firstly, thanks for nicely written library!

This PR is for accommodating id tokens sent for verification within the first second from token generation.

Since unix timestamp (integer seconds) is used for auth time info in token payloads, auth time info and current timestamp becomes identical when a token is sent within the first second of generation.

I found token verification failing often when refreshed id tokens are sent from frontend, so I've fixed the time comparison to accommodate the identical unix timestamp and it's been more stable.

I hope it's acceptable and the change can be applied to a new version.

Thanks very much!


